### PR TITLE
Veri tipi yazim hatasi giderildi

### DIFF
--- a/boeluem-1/degiskenler-ve-atanmasi.md
+++ b/boeluem-1/degiskenler-ve-atanmasi.md
@@ -5,7 +5,7 @@
 ```go
 var isim string = “Ali”
 var yas int = 20
-var ogrenci boolean = true
+var ogrenci bool = true
 ```
 
 Yukarıdaki yazdıklarımızı inceleyecek olursak;


### PR DESCRIPTION
Go dilini ogrenmeye calistigim icin yazim hatasi mi yoksa eski versiyondan kalan bir kullanim mi oldugunu anlayamadim. [Buradaki](https://go-tour-turkish.appspot.com/basics/11) kaynaga gore boolean veri tipinde bir degisken tanimlanirken `bool` seklinde yazilmasi gerekiyormus.